### PR TITLE
Simplify server logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,42 +12,45 @@ of services are used. The main objective here is to simulate web applications us
 * [SimPy](https://simpy.readthedocs.io/en/latest/simpy_intro/installation.html)
 
 ### Requirements
-* Have experimental results CSV’s with the following information: 
-  * **Service time**: A CSV with the service time of each request processed in experiment. 
-  * **Processed requests** and **shedded request** at the same window: A **CSV file** with the number of processed requests until start shedding and the number of shedded requests at the this shedding. It is a requirement to simulate GCI on experiments only, there is no need of it to simulate GCI off experiments.
-
+* Have an experimental results CSV file with the following information: 
+  * **Status**: The http status that each request has received.
+  * **Request time**: the service time of each request processed in experiment. 
+  
 ### How to run
 #### Parameters
 * **instances**: The numbers of servers to be used. It isn't straightforward, but you need pass a string with each number os instances to be simulated. Example: INSTANCES="1 2 4".
 * **duration**: How much time the simulation should take in seconds (must be integer or float).
-* **scenario**: There is two scenarios, control and baseline. Control means servers using GCI and baseline means servers with no GCI.
 * **load_per_instance**: An integer meaning how much requests the load balance must to distribute to each server.
 * **results_path**: The path where the simulator should put the results.
-* **results_name**: A name to simulator name the results.
-* **setup_info_name**: A name to simulator name the setup information files.
-* **data_path**: The path where the CSV files of experimental results are.
-* **service_time_file_name**: The name of a file with the service time of each request processed in an experiment.
-* **service_time_data_column**: The column number of that files (integer).
+* **prefix_results_name**: A pattern to simulator use it as a prefix in result names.
+* **data_path**: The path where the CSV file of the experimental results is kept.
+* **input_file_name**: The name of the CSV file with the service time and status http of each request processed in an experiment.
 * **round_start**: It defines the ID to identify the first simulation result file.
 * **round_end**: It defines the ID to identify the last simulation result file. It also means the number of simulations to be executed.
-* **shedding_file_name**: The name of the CSV file containing a pair of values needed to do shedding. 
-* **shedding_number_of_files**: The number of shedding files.
+* **debbug_log**: It is used to generate more detailed results.
 
 #### Execution
-After have cloned the simulator, move to the right director and execute one of those commands below. The command at Baseline simulates an experiment with **no GCI** on Servers, at control simulates with servers **using GCI**. The parameters must be passed as environment variables. Follow below a full example.
+After have cloned the simulator, move to the right directory and execute the command below. Note that the input file will shape your simulation behavior.
 
-* ##### **Baseline**
-  * **INSTANCES**="instances" **DURATION**="duration" **SCENARIO**="baseline" **LOAD_PER_INSTANCE**="load_per_instance" **RESULTS_PATH**="results_path" **RESULTS_NAME**="results_name" **SETUP_INFO_NAME**="setup_info_name" **DATA_PATH**="data_path" **SERVICE_TIME_FILE_NAME**="service_time_file_name" **SERVICE_TIME_DATA_COLUMN**="service_time_data_column" **ROUND_START**="round_start" **ROUND_END**="round_end" **bash** **run_simulator.sh** 
-* ##### **Control**
-  * **INSTANCES**="instances" **DURATION**="duration" **SCENARIO**="control" **LOAD_PER_INSTANCE**="load_per_instance" **RESULTS_PATH**="results_path" **RESULTS_NAME**="results_name" **SETUP_INFO_NAME**="setup_info_name" **DATA_PATH**="data_path" **SERVICE_TIME_FILE_NAME**="service_time_file_name" **SERVICE_TIME_DATA_COLUMN**="service_time_data_column" **ROUND_START**="round_start" **ROUND_END**="round_end" **SHEDDING_FILE_NAME**="shedding_file_name" **SHEDDING_NUMBER_OF_FILES**="shedding_number_of_files" **bash** **run_simulator.sh**  
+  * **INSTANCES**="instances" **DURATION**="duration" **LOAD_PER_INSTANCE**="load_per_instance" **RESULTS_PATH**="results_path" **PREFIX_RESULTS_NAME**="prefix_results_name" **DATA_PATH**="data_path" **INPUT_FILE_NAME**="input_file_name" **ROUND_START**="round_start" **ROUND_END**="round_end" **bash** **run_simulator.sh**  
 
 Please, pay attention that the script run_simulation.sh already has some of these parameters with default values that make easier run simulations. 
 
 ### Results
-The simulation will generate two kind of files: an information file and a CSV file. Both of files may be named as said before. The information file keeps the parameters used to simulate and the CSV file keeps data of each request processed during the simulation. The column description follow below. 
-* **id**: The request identify.
+The simulation will generate one or two kind of result files: If you pass no debbug key the
+simulate will generate only a simple file result containing three columns. If you pass DEBBUG=true, a more detailed 
+result will be created. The debbug result has the same name as the normal file but with debbug 
+as sufix. The bullets below explains what each column represent.
+* **id**: A number that identifies some request.
+* **timestamp**: The moment at the request was finished.
 * **created_time**: The moment at the request was created.
-* **latency**: The all life time of a request processed startind at its created moment until it be processed and finished.
-* **service_time**: Is only the time that the request have passed in a server. 
+* **latency**: The all life time of a request processed starting at its created moment until it be processed and finished.
+* **service_time**: It is only the time that the request have passed in a server. 
+* **status**: It gives the http status of a request. 200 means successfully request, 503 means failed requests.  
 * **done**: It gives the request state. True if the request was processed and False otherwise. 
 * **times_forwarded**: It gives how many times a request was sent to a server.
+
+Since who run a simulation have chose a prefix name, the result name radical is always named 
+based on simulation configuration following the pattern "duration_load_instances_round", where "duration" means the
+simulation duration, "load" means how much request where sent each second, "instances" means how much instances where used and
+"round" means which round each file belongs to.

--- a/__main__.py
+++ b/__main__.py
@@ -29,13 +29,12 @@ def main():
     env_var = os.environ
     NUMBER_OF_SERVERS = int(env_var['NUMBER_OF_SERVERS'])
     DURATION = float(env_var['DURATION'])
-    LOAD = int(env_var['LOAD'] )
+    LOAD = int(env_var['LOAD'])
     RESULTS_PATH = env_var['RESULTS_PATH']
-    create_directory(RESULTS_PATH)
 
     DATA_PATH = env_var['DATA_PATH']
-    SERVICE_TIME_FILE_NAME = env_var['SERVICE_TIME_FILE_NAME']
-    data = build_data(DATA_PATH + SERVICE_TIME_FILE_NAME)
+    INPUT_FILE_NAME = env_var['INPUT_FILE_NAME']
+    data = build_data(DATA_PATH + INPUT_FILE_NAME)
 
     env = simpy.Environment()
 
@@ -58,8 +57,8 @@ def main():
     RESULTS_NAME = env_var['RESULTS_NAME']
     log_request(load_balancer.requests, RESULTS_PATH, RESULTS_NAME, "w")
 
-    if env_var['DEBBUG'].upper() == "TRUE":
-        log_debbug(load_balancer.requests, RESULTS_PATH + "debbug/", RESULTS_NAME, "w")
+    if env_var['DEBBUG_LOG'] == "true":
+        log_debbug(load_balancer.requests, RESULTS_PATH, RESULTS_NAME, "w")
 
     text = "created requests: " + str(load_balancer.created_requests) \
            + "\nshedded requests: " + str(load_balancer.shedded_requests) \

--- a/__main__.py
+++ b/__main__.py
@@ -1,5 +1,5 @@
-from models import LoadBalancer, ServerControl, ServerBaseline
-from log import log_request
+from models import LoadBalancer, Server
+from log import log_request, log_debbug
 import simpy, os, time
 
 
@@ -8,13 +8,14 @@ def create_directory(path):
         os.mkdir(path)
 
 
-def build_data(file_name, column):
+def build_data(file_name):
     data = list()
     file_obj = open(file_name + ".csv", 'r')
     for linha in file_obj:
         try:
             result = list(map(float, linha.split(",")))
-            data.append(result[column])
+            result.pop(0)  # removes the timestamp column
+            data.append(result)
         except:
             # avoid invalid values.
             pass
@@ -26,17 +27,15 @@ def main():
     before = time.time()
 
     env_var = os.environ
-    NUMBER_OF_SERVERS = int(env_var['NUMBER_OF_SERVERS'] )
-    DURATION = float(env_var['DURATION'] )
-    SCENARIO = env_var['SCENARIO']
+    NUMBER_OF_SERVERS = int(env_var['NUMBER_OF_SERVERS'])
+    DURATION = float(env_var['DURATION'])
     LOAD = int(env_var['LOAD'] )
     RESULTS_PATH = env_var['RESULTS_PATH']
     create_directory(RESULTS_PATH)
 
     DATA_PATH = env_var['DATA_PATH']
     SERVICE_TIME_FILE_NAME = env_var['SERVICE_TIME_FILE_NAME']
-    SERVICE_TIME_DATA_COLUMN = int(env_var['SERVICE_TIME_DATA_COLUMN'] )
-    service_time_data = build_data(DATA_PATH + SERVICE_TIME_FILE_NAME, SERVICE_TIME_DATA_COLUMN)
+    data = build_data(DATA_PATH + SERVICE_TIME_FILE_NAME)
 
     env = simpy.Environment()
 
@@ -49,24 +48,7 @@ def main():
     servers = list()
     load_balancer = LoadBalancer(loadbalancer_load, env)
     for i in range(NUMBER_OF_SERVERS):
-        if SCENARIO == 'control':
-            PROCESSED_REQUESTS_FILE_NAME = env_var['SHEDDING_FILE_NAME']
-            PROCESSED_REQUESTS_COLUMN = 0
-            NUMBER_OF_FILES = int(env_var['SHEDDING_NUMBER_OF_FILES'])
-            processed_requests_data = build_data(DATA_PATH + PROCESSED_REQUESTS_FILE_NAME + str((i % NUMBER_OF_FILES) + 1), PROCESSED_REQUESTS_COLUMN)
-
-            SHEDDED_REQUESTS_FILE_NAME = env_var['SHEDDING_FILE_NAME']
-            SHEDDED_REQUESTS_COLUMN = 1
-            shedded_requests_data = build_data(DATA_PATH + SHEDDED_REQUESTS_FILE_NAME + str((i % NUMBER_OF_FILES) + 1), SHEDDED_REQUESTS_COLUMN)
-
-            server = ServerControl(env, i, service_time_data, processed_requests_data, shedded_requests_data)
-
-        elif SCENARIO == 'baseline':
-            server = ServerBaseline(env, i, service_time_data)
-
-        else:
-            raise Exception("INVALID SCENARIO")
-
+        server = Server(env, i, data)
         load_balancer.add_server(server)
         servers.append(server)
 
@@ -75,6 +57,9 @@ def main():
 
     RESULTS_NAME = env_var['RESULTS_NAME']
     log_request(load_balancer.requests, RESULTS_PATH, RESULTS_NAME, "w")
+
+    if env_var['DEBBUG'].upper() == "TRUE":
+        log_debbug(load_balancer.requests, RESULTS_PATH + "debbug/", RESULTS_NAME, "w")
 
     text = "created requests: " + str(load_balancer.created_requests) \
            + "\nshedded requests: " + str(load_balancer.shedded_requests) \

--- a/log.py
+++ b/log.py
@@ -23,11 +23,11 @@ def log_request(requests, results_path, results_name, mode):
 def log_debbug(requests, debbug_path, debbug_name, mode):
     data = []
     if mode == "w":
-        data.append(["id", "created_time", "finished_time", "latency",
+        data.append(["id", "timestamp", "created_time", "latency",
                      "service_time", "status", "done", "times_forwarded"])
 
     for request in requests:
-        data.append([request.id, request.created_time, request.finished_time, request._latency,
+        data.append([request.id, request.finished_time * 1000, request.created_time, request._latency,
                      request.service_time, request.status, request.done, request.times_forwarded])
 
     file_path = debbug_path + "/" + debbug_name + "_debbug.csv"

--- a/log.py
+++ b/log.py
@@ -14,7 +14,7 @@ def log_request(requests, results_path, results_name, mode):
         data.append(["timestamp", "status", "request_time"])
 
     for request in requests:
-        data.append([request.finished_time, request.status, request._latency])
+        data.append([request.finished_time * 1000, request.status, request._latency * 1000])
 
     file_path = results_path + "/" + results_name + ".csv"
     csv_writer(data, file_path, mode)
@@ -30,6 +30,6 @@ def log_debbug(requests, debbug_path, debbug_name, mode):
         data.append([request.id, request.created_time, request.finished_time, request._latency,
                      request.service_time, request.status, request.done, request.times_forwarded])
 
-    file_path = debbug_path + "/" + debbug_name + ".csv"
+    file_path = debbug_path + "/" + debbug_name + "_debbug.csv"
     csv_writer(data, file_path, mode)
 

--- a/log.py
+++ b/log.py
@@ -11,10 +11,25 @@ def csv_writer(data, path, mode):
 def log_request(requests, results_path, results_name, mode):
     data = []
     if mode == "w":
-        data.append(["id", "created_time", "latency", "service_time",  "done", "times_forwarded"])
+        data.append(["timestamp", "status", "request_time"])
 
     for request in requests:
-        data.append([request.id, request.created_time, request._latency, request.service_time, request.done, request.times_forwarded])
+        data.append([request.finished_time, request.status, request._latency])
 
     file_path = results_path + "/" + results_name + ".csv"
     csv_writer(data, file_path, mode)
+
+
+def log_debbug(requests, debbug_path, debbug_name, mode):
+    data = []
+    if mode == "w":
+        data.append(["id", "created_time", "finished_time", "latency",
+                     "service_time", "status", "done", "times_forwarded"])
+
+    for request in requests:
+        data.append([request.id, request.created_time, request.finished_time, request._latency,
+                     request.service_time, request.status, request.done, request.times_forwarded])
+
+    file_path = debbug_path + "/" + debbug_name + ".csv"
+    csv_writer(data, file_path, mode)
+

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,3 +1,3 @@
 from .request import Request
 from .loadbalancer import LoadBalancer
-from .server import ServerBaseline, ServerControl, Distribution, Reproduction
+from .server import Server

--- a/models/loadbalancer.py
+++ b/models/loadbalancer.py
@@ -7,7 +7,7 @@ class LoadBalancer(object):
         self.create_request_rate = create_request_rate
         self.env = env
 
-        self.comunication_delay = 0.008 # 8ms
+        self.comunication_delay = 0.001 # 1ms
         self.sleep = 0.00001 #  0.01ms
 
         self.requests = list()

--- a/models/loadbalancer.py
+++ b/models/loadbalancer.py
@@ -7,7 +7,7 @@ class LoadBalancer(object):
         self.create_request_rate = create_request_rate
         self.env = env
 
-        self.comunication_delay = 0.008 # 1ms
+        self.comunication_delay = 0.008 # 8ms
         self.sleep = 0.00001 #  0.01ms
 
         self.requests = list()

--- a/models/request.py
+++ b/models/request.py
@@ -6,9 +6,11 @@ class Request(object):
         self.env = env
         self.id = id
         self.load_balancer = load_balancer
-        self.service_time = 0
 
         self.created_time = created_at  # The moment when the request was created
+        self.finished_time = None
+
+        self.service_time = 0
         self.times_forwarded = 0
         self._arrived_time = None  # The moment when the request arrived at server
         self._latency = None
@@ -25,5 +27,6 @@ class Request(object):
         self._arrived_time = arrived_time
 
     def finished_at(self, finished_time):
+        self.finished_time = finished_time
         self._latency = finished_time - self.created_time
 

--- a/models/request.py
+++ b/models/request.py
@@ -14,9 +14,10 @@ class Request(object):
         self._latency = None
 
         self.done = False
+        self.status = None
 
     def run(self, service_time):
-        self.service_time = service_time
+        self.service_time += service_time
         yield self.env.timeout(service_time)
         self.done = True
 

--- a/models/server.py
+++ b/models/server.py
@@ -1,9 +1,11 @@
+import random
+
 
 class DataIterator(object):
 
     def __init__(self, data):
         self.data = data
-        self.index = -1  # This -1 ensures the first next_value() has a self.index with value 0.
+        self.index = random.randint(0, len(data) - 1)
 
     def next_value(self):
         self.index = (self.index + 1) % len(self.data)

--- a/models/server.py
+++ b/models/server.py
@@ -29,6 +29,7 @@ class Server(object):
         service_time = tmp[1]
 
         if status == "503":
+            yield self.env.timeout(service_time)
             request.service_time += service_time
             yield self.env.process(request.load_balancer.shed_request(request))
 

--- a/models/server.py
+++ b/models/server.py
@@ -1,78 +1,47 @@
-import random
 
-
-class Distribution(object):
+class DataIterator(object):
 
     def __init__(self, data):
         self.data = data
-        self.max = len(self.data)-1
-        self.min = 0
-
-    def next_value(self):
-        return self.data[random.randint(self.min, self.max)]
-
-
-class ServerBaseline(object):
-
-    def __init__(self, env, id, service_time_data):
-        self.env = env
-        self.id = id
-        self.service_time_distribution = Distribution(service_time_data)
-
-        self.requests_arrived = 0
-        self.processed_requests = 0
-        self.requests = list()
-
-    def request_arrived(self, request):
-        self.requests_arrived += 1
-        request.arrived_at(self.env.now)
-        yield self.env.process(self.process_request(request))
-
-    def process_request(self, request):
-        yield self.env.process(request.run(self.service_time_distribution.next_value()))
-        yield self.env.process(request.load_balancer.request_succeeded(request))
-        self.processed_requests += 1
-        self.requests.append(request)
-
-
-class Reproduction(object):
-
-    def __init__(self, data):
-        self.data = data
-        self.index = -1
+        self.index = -1  # This -1 ensures the first next_value() has a self.index with value 0.
 
     def next_value(self):
         self.index = (self.index + 1) % len(self.data)
         return self.data[self.index]
 
 
-class ServerControl(ServerBaseline):
+class Server(object):
 
-    def __init__(self, env, id, service_time_data, processed_request_data, shedded_request_data):
-        super().__init__(env, id, service_time_data)
+    def __init__(self, env, id, data):
+        self.env = env
+        self.id = id
+        self.data = DataIterator(data)
 
-        self.requests_finished_distribution = Reproduction(processed_request_data)
-        self.finished = int(self.requests_finished_distribution.next_value())
-
-        self.requests_shedded_distribution = Reproduction(shedded_request_data)
-        self.shedded = int(self.requests_shedded_distribution.next_value())
+        self.requests_arrived = 0
+        self.processed_requests = 0
+        self.requests = list()
 
         self.is_shedding = False
 
     def request_arrived(self, request):
-        if self.is_shedding:
-            self.shedded -= 1
-            if self.shedded == 0:
-                self.is_shedding = False
-                self.finished = int(self.requests_finished_distribution.next_value())
+        tmp = self.data.next_value()
+        status = tmp[0]
+        service_time = tmp[1]
 
+        if status == "503":
+            request.service_time += service_time
             yield self.env.process(request.load_balancer.shed_request(request))
 
-        else:
-            yield self.env.process(super().request_arrived(request))
-            if not self.is_shedding:
-                self.finished -= 1
-                if self.finished == 0:
-                    self.is_shedding = True
-                    self.shedded = int(self.requests_shedded_distribution.next_value())
+        elif status == "200":
+            self.requests_arrived += 1
+            request.arrived_at(self.env.now)
+            yield self.env.process(self.process_request(request, service_time))
 
+        else:
+            raise Exception("INVALID LATENCY DATA")
+
+    def process_request(self, request, service_time):
+        yield self.env.process(request.run(service_time))
+        yield self.env.process(request.load_balancer.request_succeeded(request))
+        self.processed_requests += 1
+        self.requests.append(request)

--- a/models/server.py
+++ b/models/server.py
@@ -25,15 +25,16 @@ class Server(object):
 
     def request_arrived(self, request):
         tmp = self.data.next_value()
-        status = tmp[0]
-        service_time = tmp[1]
+        status = int(tmp[0])
+        service_time = tmp[1] / 1000.0  # We use seconds as unit of time.
+        request.status = status
 
-        if status == "503":
+        if status == 503:
             yield self.env.timeout(service_time)
             request.service_time += service_time
             yield self.env.process(request.load_balancer.shed_request(request))
 
-        elif status == "200":
+        elif status == 200:
             self.requests_arrived += 1
             request.arrived_at(self.env.now)
             yield self.env.process(self.process_request(request, service_time))

--- a/run_simulator.sh
+++ b/run_simulator.sh
@@ -5,7 +5,7 @@ set -x
 
 echo "ROUND_START: ${ROUND_START:=1}"
 echo "ROUND_END: ${ROUND_END:=1}"
-echo "INSTANCES: ${ISNTANCES:=1 2 4}"
+echo "INSTANCES: ${INSTANCES:=1 2 4}"
 echo "DURATION: ${DURATION:=300}"
 echo "LOAD_PER_INSTANCE: ${LOAD_PER_INSTANCE:=40}"
 echo "RESULTS_PATH: ${RESULTS_PATH:=/tmp/simulation/}"
@@ -13,15 +13,18 @@ mkdir -p $RESULTS_PATH
 
 echo "GENERAL_RESULTS_NAME: ${GENERAL_RESULTS_NAME}"
 echo "DATA_PATH: ${DATA_PATH}"
-echo "SERVICE_TIME_FILE_NAME: ${SERVICE_TIME_FILE_NAME}"
+echo "INPUT_FILE_NAME: ${INPUT_FILE_NAME}"
+echo "DEBBUG_LOG: ${DEBBUG_LOG:='false'}"
 
 for instance in ${INSTANCES};
 do
 	for round in `seq ${ROUND_START} ${ROUND_END}`
 	do
-		echo "\nround ${round}: Simulating ${instance} instance(s)..."
-		NUMBER_OF_SERVERS=$instance LOAD=$(($LOAD_PER_INSTANCE * $instance)) RESULTS_NAME="${GENERAL_RESULTS_NAME}_${DURATION}_${LOAD}_${instance}_${round}" python3 __main__.py
-		echo "round ${round}: Finished.\n"
+    	echo ""
+		echo "round ${round}: Simulating ${instance} instance(s)..."
+	    NUMBER_OF_SERVERS=$instance DURATION=$DURATION LOAD=$(($LOAD_PER_INSTANCE * $instance)) RESULTS_PATH=$RESULTS_PATH DATA_PATH=$DATA_PATH INPUT_FILE_NAME=$INPUT_FILE_NAME RESULTS_NAME="${GENERAL_RESULTS_NAME}_${DURATION}_${LOAD}_${instance}_${round}" DEBBUG_LOG=$DEBBUG_LOG python3 __main__.py
+		echo "round ${round}: Finished."
+		echo ""
 	done
 done
 

--- a/run_simulator.sh
+++ b/run_simulator.sh
@@ -6,36 +6,22 @@ set -x
 echo "ROUND_START: ${ROUND_START:=1}"
 echo "ROUND_END: ${ROUND_END:=1}"
 echo "INSTANCES: ${ISNTANCES:=1 2 4}"
-echo "DURATION: ${DURATION:=120}"
-echo "LOAD_PER_INSTANCE: ${LOAD_PER_INSTANCE:=80}"
-echo "SCENARIO: ${SCENARIO:=control}"
-echo "RESULTS_PATH: ${RESULTS_PATH:=/tmp/simulation/${NUMBER_OF_SERVERS}i/${SCENARIO}/}"
+echo "DURATION: ${DURATION:=300}"
+echo "LOAD_PER_INSTANCE: ${LOAD_PER_INSTANCE:=40}"
+echo "RESULTS_PATH: ${RESULTS_PATH:=/tmp/simulation/}"
 mkdir -p $RESULTS_PATH
 
-echo "RESULTS_NAME: ${RESULTS_NAME}"
+echo "GENERAL_RESULTS_NAME: ${GENERAL_RESULTS_NAME}"
 echo "DATA_PATH: ${DATA_PATH}"
 echo "SERVICE_TIME_FILE_NAME: ${SERVICE_TIME_FILE_NAME}"
-echo "SERVICE_TIME_DATA_COLUMN: ${SERVICE_TIME_DATA_COLUMN}"
-echo "SHEDDING_FILE_NAME: ${SHEDDING_FILE_NAME}"
-echo "SHEDDING_NUMBER_OF_FILES: ${SHEDDING_NUMBER_OF_FILES}"
-echo "SETUP_INFO: ${SETUP_INFO:=setup_info.txt}"
-
 
 for instance in ${INSTANCES};
 do
 	for round in `seq ${ROUND_START} ${ROUND_END}`
 	do
-		echo ""
-		echo "round ${round}: Simulating ${instance} instance(s)..."
-		LOAD=$(($LOAD_PER_INSTANCE * $instance)) NUMBER_OF_SERVERS=$instance python3 __main__.py
-		mkdir -p $RESULTS_PATH${instance}i/
-		mv "${RESULTS_PATH}${RESULTS_NAME}.csv" "${RESULTS_PATH}${instance}i/${RESULTS_NAME}_${round}.csv"
-		echo "round ${round}: Finished."
-		echo ""
-	done 
-	
-	INFO="number of service instances: ${instance}\nsimulation time duration: ${DURATION}\nconfiguration scenario: ${SCENARIO}\nworkload per instance: ${LOAD_PER_INSTANCE}req/sec\ngeneral workload: $(($LOAD_PER_INSTANCE * ${instance}))req/sec"
-	echo -e $INFO > $RESULTS_PATH${instance}i/$SETUP_INFO
-	
+		echo "\nround ${round}: Simulating ${instance} instance(s)..."
+		NUMBER_OF_SERVERS=$instance LOAD=$(($LOAD_PER_INSTANCE * $instance)) RESULTS_NAME="${GENERAL_RESULTS_NAME}_${DURATION}_${LOAD}_${instance}_${round}" python3 __main__.py
+		echo "round ${round}: Finished.\n"
+	done
 done
 

--- a/run_simulator.sh
+++ b/run_simulator.sh
@@ -4,14 +4,14 @@ date
 set -x
 
 echo "ROUND_START: ${ROUND_START:=1}"
-echo "ROUND_END: ${ROUND_END:=1}"
+echo "ROUND_END: ${ROUND_END:=4}"
 echo "INSTANCES: ${INSTANCES:=1 2 4}"
 echo "DURATION: ${DURATION:=300}"
 echo "LOAD_PER_INSTANCE: ${LOAD_PER_INSTANCE:=40}"
 echo "RESULTS_PATH: ${RESULTS_PATH:=/tmp/simulation/}"
 mkdir -p $RESULTS_PATH
 
-echo "GENERAL_RESULTS_NAME: ${GENERAL_RESULTS_NAME}"
+echo "PREFIX_RESULTS_NAME: ${PREFIX_RESULTS_NAME}"
 echo "DATA_PATH: ${DATA_PATH}"
 echo "INPUT_FILE_NAME: ${INPUT_FILE_NAME}"
 echo "DEBBUG_LOG: ${DEBBUG_LOG:='false'}"
@@ -22,7 +22,7 @@ do
 	do
     	echo ""
 		echo "round ${round}: Simulating ${instance} instance(s)..."
-	    NUMBER_OF_SERVERS=$instance DURATION=$DURATION LOAD=$(($LOAD_PER_INSTANCE * $instance)) RESULTS_PATH=$RESULTS_PATH DATA_PATH=$DATA_PATH INPUT_FILE_NAME=$INPUT_FILE_NAME RESULTS_NAME="${GENERAL_RESULTS_NAME}_${DURATION}_${LOAD}_${instance}_${round}" DEBBUG_LOG=$DEBBUG_LOG python3 __main__.py
+	    NUMBER_OF_SERVERS=$instance DURATION=$DURATION LOAD=$(($LOAD_PER_INSTANCE * $instance)) RESULTS_PATH=$RESULTS_PATH DATA_PATH=$DATA_PATH INPUT_FILE_NAME=$INPUT_FILE_NAME RESULTS_NAME="${PREFIX_RESULTS_NAME}_${DURATION}_${LOAD}_${instance}_${round}" DEBBUG_LOG=$DEBBUG_LOG python3 __main__.py
 		echo "round ${round}: Finished."
 		echo ""
 	done

--- a/tests/context.py
+++ b/tests/context.py
@@ -2,4 +2,4 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-from models import LoadBalancer, Request, ServerBaseline, ServerControl, Distribution, Reproduction
+from models import LoadBalancer, Request, Server

--- a/tests/test_loadbalancer.py
+++ b/tests/test_loadbalancer.py
@@ -1,4 +1,4 @@
-from context import LoadBalancer, ServerBaseline, ServerControl
+from context import LoadBalancer, Server
 import unittest
 import simpy
 
@@ -9,8 +9,8 @@ class TestLoadBalancer(unittest.TestCase):
     def setUp(self):
         self.env = simpy.Environment()
         id = 0
-        service_time_data = [6]
-        self.server = ServerBaseline(self.env, id, service_time_data)
+        log_data = [["200", 6000]]
+        self.server = Server(self.env, id, log_data)
         create_request_rate = 80
         self.lb = LoadBalancer(create_request_rate, self.env, self.server)
 
@@ -46,11 +46,10 @@ class TestLoadBalancer(unittest.TestCase):
         self.assert_equal(8000, self.lb.created_requests)
 
     def test_forward(self):
-
         servers = [self.server]
-        service_time_data = [6]
+        log_data = [["200", 6000]]
         for i in range(1, 4):
-            servers.append(ServerBaseline(self.env, i, service_time_data))
+            servers.append(Server(self.env, i, log_data))
             self.lb.add_server(servers[i])
 
         self.env.run(0.05) # run enough time to send only 4 requests.
@@ -65,18 +64,14 @@ class TestLoadBalancer(unittest.TestCase):
 
     def test_shed(self):
         id = 0
-        service_time_data = [0.01]
-        processed_request_data = [1]
-        shedded_request_data = [2]
-        self.lb.servers[0] = ServerControl(self.env, id, service_time_data, processed_request_data, shedded_request_data)
+        log_data = [["200", 10], ["503", 0], ["503", 0]]
+        self.lb.servers[0] = Server(self.env, id, log_data)
 
         id = 1
-        service_time_data = [0.01]
-        processed_request_data = [2]
-        shedded_request_data = [1]
-        self.lb.add_server(ServerControl(self.env, id, service_time_data, processed_request_data, shedded_request_data))
+        log_data = [["200", 10], ["200", 10], ["503", 0]]
+        self.lb.add_server(Server(self.env, id, log_data))
 
-        self.env.run(0.05)
+        self.env.run(0.05)  # 80 in 1s, 8 in 0.1s, 4 in 0.05s.
 
         self.assertTrue(self.lb.requests[0].done)
         self.assertTrue(self.lb.requests[1].done)
@@ -88,8 +83,8 @@ class TestLoadBalancer(unittest.TestCase):
         self.assert_equal(2, self.lb.requests[2].times_forwarded)
         self.assert_equal(2, self.lb.requests[3].times_forwarded)
 
-        self.assert_equal(1, self.lb.lost_requests) # only one requests have be shedded by both servers
-        self.assert_equal(3, self.lb.shedded_requests) # One request were shedded by one server and processed by the other and one request were shedded by both servers.
+        self.assert_equal(1, self.lb.lost_requests)  # only one requests have be shedded by both servers
+        self.assert_equal(3, self.lb.shedded_requests)  # One request were shedded by one server and processed by the other and one request were shedded by both servers.
 
 
 if __name__ == '__main__':

--- a/tests/test_loadbalancer.py
+++ b/tests/test_loadbalancer.py
@@ -66,10 +66,12 @@ class TestLoadBalancer(unittest.TestCase):
         id = 0
         log_data = [["200", 10], ["503", 0], ["503", 0]]
         self.lb.servers[0] = Server(self.env, id, log_data)
+        self.lb.servers[0].data.index = -1  # ensures that we start from beginning since at next_value call it becomes 0.
 
         id = 1
         log_data = [["200", 10], ["200", 10], ["503", 0]]
         self.lb.add_server(Server(self.env, id, log_data))
+        self.lb.servers[1].data.index = -1  # ensures that we start from beginning since at next_value call it becomes 0
 
         self.env.run(0.05)  # 80 in 1s, 8 in 0.1s, 4 in 0.05s.
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -40,6 +40,8 @@ class TestServer(unittest.TestCase):
         id = 0
         log_data = [["200", 1], ["200", 1], ["200", 1], ["503", 1]]
         server = Server(self.env, id, log_data)
+        server.data.index = -1  # ensures that we start from beginning since at next_value call it becomes 0
+
         self.lb.add_server(server)
 
         self.env.run(0.05)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,4 +1,4 @@
-from context import LoadBalancer, ServerBaseline, ServerControl, Distribution, Reproduction
+from context import LoadBalancer, Server
 import unittest
 import simpy
 
@@ -16,22 +16,10 @@ class TestServer(unittest.TestCase):
     def assert_equal(self, expected, received):
         self.assertEqual(expected, received, msg=self.failure_msg(expected, received))
 
-    def test_reproduction_and_distribution(self):
-        data = []
-        for i in range(1000):
-            data.append(i)
-
-        distribution = Distribution(data)
-        reproduction = Reproduction(data)
-
-        for i in range(1000):
-            self.assert_equal(i, reproduction.next_value())
-            self.assertTrue(distribution.next_value() in data)
-
     def test_server_baseline(self):
         id = 0
-        service_time_data = [0.001]
-        server = ServerBaseline(self.env, id, service_time_data)
+        log_data = [["200", 1]]
+        server = Server(self.env, id, log_data)
         self.lb.add_server(server)
 
         self.env.run(0.05)
@@ -50,10 +38,8 @@ class TestServer(unittest.TestCase):
 
     def test_server_control(self):
         id = 0
-        service_time_data = [0.001]
-        processed_request_data = [3]
-        shedded_request_data = [1]
-        server = ServerControl(self.env, id, service_time_data, processed_request_data, shedded_request_data)
+        log_data = [["200", 1], ["200", 1], ["200", 1], ["503", 1]]
+        server = Server(self.env, id, log_data)
         self.lb.add_server(server)
 
         self.env.run(0.05)


### PR DESCRIPTION
Change the server logic to a much more simple and instead of use two different input files we now only use one.  
Current state:
+ only one server abstraction (no more ServerBaseline and ServerControl).
+ servers chose when shed a request by a http status from a input file.
+ script to run simulations simplified.
+ log.py now also generate debbug files.
+ tests, main and readme updated.